### PR TITLE
Added service discovery function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,95 @@
-![build-status](https://travis-ci.com/theonestack/hl-component-aurora-postgres.svg?branch=master)
+# aurora (Postgres) CfHighlander component
+## Parameters
 
-### Cfhighlander Aurora Postgres component
+| Name | Use | Default | Global | Type | Allowed Values |
+| ---- | --- | ------- | ------ | ---- | -------------- |
+| EnvironmentName | Tagging | dev | true | string
+| EnvironmentType | Tagging | development | true | string | ['development','production']
+| VPCId | Security Groups | None | false | AWS::EC2::VPC::Id
+| DnsDomain | DNS domain to use | None | true | string
+| SubnetIds | List of subnets | None | false | CommaDelimitedList
+| KmsKeyId | KMS ID | None | false | string (arn)
+| NamespaceId | Service discovery namespace ID | None | false | string
+| SnapshotId | Snapshot ID to provision from | None | false | string
+| WriterInstanceType | Writer instance type *if engine is set to provisioned* | None | false | string
+| ReaderInstanceType | Reader instance type *if engine is set to provisioned* | None | false | string
+## Outputs/Exports
+
+| Name | Value | Exported |
+| ---- | ----- | -------- |
+| SecurityGroup | Security Group name | true
+| ServiceRegistry | CloudMap service registry ID | true
+| DBClusterId | Database Cluster ID | true
+
+## Included Components
+
+[lib-ec2](https://github.com/theonestack/hl-component-lib-ec2)
+
+## Example Configuration
+### Highlander
+```
+  Component name:'database', template: 'aurora-postgres' do
+    parameter name: 'DnsDomain', value: root_domain
+    parameter name: 'DnsFormat', value: FnSub("${EnvironmentName}.#{root_domain}")
+    parameter name: 'SubnetIds', value: cfout('vpcv2', 'PersistenceSubnets')
+    parameter name: 'WriterInstanceType', value: writer_instance
+    parameter name: 'ReaderInstanceType', value: reader_instance
+    parameter name: 'EnableReader', value: 'true'
+    parameter name: 'StackOctet', value: '80'
+    parameter name: 'NamespaceId', value: cfout('servicediscovery', 'NamespaceId')
+  end
+```
+
+### Aurora Postgres Configuration
+```
+hostname: db
+database_name: appdb
+dns_format: ${DnsFormat}
+
+storage_encrypted: true
+engine: aurora-postgres
+engine_version: '13.4'
+
+writer_instance: db.r3.large
+reader_instance: db.r3.large
+
+master_login: 
+    username_ssm_param: /${EnvironmentName}/myapp/dbuser
+    password_ssm_param: /${EnvironmentName}/myapp/dbpass
+
+security_group:
+  -
+    rules:
+      -
+        IpProtocol: tcp
+        FromPort: 5432
+        ToPort: 5432
+    ips:
+      - stack
+      - company_office
+      - company_client_vpn
+
+service_discovery:
+  name: db
+```
+
+## Cfhighlander Setup
+
+install cfhighlander [gem](https://github.com/theonestack/cfhighlander)
 
 ```bash
-
-# install highlander gem
-$ gem install cfhighlander
-
-# build and validate standalone component
-$ cfcompile --validate
-
+gem install cfhighlander
 ```
-### Usage
 
-### Configuration options
+or via docker
 
-TBD
+```bash
+docker pull theonestack/cfhighlander
+```
+## Testing Components
 
-### Parameters
+Running the tests
 
-TBD
-
-### Configuration options
-
-TBD
-
-### Outputs
-
-TBD
+```bash
+cfhighlander cftest aurora-postgres
+```

--- a/aurora-postgres.cfhighlander.rb
+++ b/aurora-postgres.cfhighlander.rb
@@ -13,6 +13,8 @@ CfhighlanderTemplate do
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
     ComponentParam 'KmsKeyId' if (defined? kms) && (kms)
+
+    ComponentParam 'NamespaceId' if defined? service_discovery
   end
-  
+
 end

--- a/aurora-postgres.cfndsl.rb
+++ b/aurora-postgres.cfndsl.rb
@@ -19,8 +19,8 @@ CloudFormation do
     }
     if rule['security_group_id']
       sg_rule['SourceSecurityGroupId'] = FnSub(rule['security_group_id'])
-    else 
-      sg_rule['CidrIp'] = FnSub(rule['ip']) 
+    else
+      sg_rule['CidrIp'] = FnSub(rule['ip'])
     end
     if rule['desc']
       sg_rule['Description'] = FnSub(rule['desc'])
@@ -38,7 +38,7 @@ CloudFormation do
         Description: "outbound all for ports",
         IpProtocol: -1,
       }
-    ]) 
+    ])
     Tags aurora_tags
   end
 
@@ -106,7 +106,7 @@ CloudFormation do
     DBInstanceClass Ref(:ReaderInstanceType)
     Tags aurora_tags
   }
-  
+
   Route53_RecordSet(:DBClusterReaderRecord) {
     Condition(:EnableReader)
     HostedZoneName FnJoin('', [ Ref('EnvironmentName'), '.', Ref('DnsDomain'), '.'])
@@ -123,6 +123,40 @@ CloudFormation do
     TTL '60'
     ResourceRecords [ FnGetAtt('DBCluster','Endpoint.Address') ]
   }
+
+  registry = {}
+  service_discovery = external_parameters.fetch(:service_discovery, {})
+
+  unless service_discovery.empty?
+    ServiceDiscovery_Service(:ServiceRegistry) {
+      NamespaceId Ref(:NamespaceId)
+      Name service_discovery['name']  if service_discovery.has_key? 'name'
+      DnsConfig({
+        DnsRecords: [{
+          TTL: 60,
+          Type: 'CNAME'
+        }],
+        RoutingPolicy: 'WEIGHTED'
+      })
+      if service_discovery.has_key? 'healthcheck'
+        HealthCheckConfig service_discovery['healthcheck']
+      else
+        HealthCheckCustomConfig ({ FailureThreshold: (service_discovery['failure_threshold'] || 1) })
+      end
+    }
+
+    ServiceDiscovery_Instance(:RegisterInstance) {
+      InstanceAttributes(
+        AWS_INSTANCE_CNAME: FnGetAtt('DBCluster','Endpoint.Address')
+      )
+      ServiceId Ref(:ServiceRegistry)
+    }
+
+    Output(:ServiceRegistry) {
+      Value(Ref(:ServiceRegistry))
+      Export FnSub("${EnvironmentName}-#{external_parameters[:component_name]}-CloudMapService")
+    }
+  end
 
   Output(:DBClusterId) {
     Value(Ref(:DBCluster))

--- a/tests/service_registry.test.yaml
+++ b/tests/service_registry.test.yaml
@@ -1,0 +1,7 @@
+test_metadata:
+  type: config
+  name: enable service registry
+  description: If you specify service_registry in the config, it should then expect the namespace component paremeter, and add service_discovery['name'] as the record
+
+service_discovery:
+  name: db


### PR DESCRIPTION
A customer of ours needed their DB to be accessible via their internal AWS Cloud Map namespace (using "db"), and setting the DNS zone to "dev.local" (their namespace) gave an error because the Route53 component can't edit AWS Cloud Map zones.

I (mostly) just copied the way ECS-Services add themselves to Service Registry, except in this case it just points to the CNAME that RDS creates.