### PR TITLE
Add Enhanced Monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 | SnapshotId | Snapshot ID to provision from | None | false | string
 | WriterInstanceType | Writer instance type *if engine is set to provisioned* | None | false | string
 | ReaderInstanceType | Reader instance type *if engine is set to provisioned* | None | false | string
+| EnhancedMonitoringInterval | Enhanced Monitoring granularity in seconds. Set to 0 to disable. | 0 | false | string | ['0','1','5','10','15','30','60']
 ## Outputs/Exports
 
 | Name | Value | Exported |
@@ -72,6 +73,18 @@ security_group:
 service_discovery:
   name: db
 ```
+
+## Enhanced Monitoring
+
+RDS Enhanced Monitoring provides OS-level metrics (CPU, memory, file system, disk I/O) at up to per-second granularity.
+
+Enable at deploy time by setting the `EnhancedMonitoringInterval` parameter:
+
+```bash
+EnhancedMonitoringInterval=60
+```
+
+When enabled, the component creates an IAM role with the `AmazonRDSEnhancedMonitoringRole` managed policy and configures monitoring on all DB instances (writer, reader, serverless). Set to `0` to disable (default).
 
 ## Cfhighlander Setup
 

--- a/aurora-postgres.cfhighlander.rb
+++ b/aurora-postgres.cfhighlander.rb
@@ -25,6 +25,7 @@ CfhighlanderTemplate do
     end
     
     ComponentParam 'NamespaceId' if defined? service_discovery
+    ComponentParam 'EnhancedMonitoringInterval', '0', allowedValues: ['0', '1', '5', '10', '15', '30', '60']
   end
 
 end

--- a/aurora-postgres.cfndsl.rb
+++ b/aurora-postgres.cfndsl.rb
@@ -220,11 +220,21 @@ CloudFormation do
   maint_window = external_parameters.fetch(:maint_window, nil) # key kept for backwards compatibility
   writer_maintenance_window = external_parameters.fetch(:writer_maintenance_window, maint_window)
 
+  Condition(:EnableEnhancedMonitoring, FnNot(FnEquals(Ref(:EnhancedMonitoringInterval), '0')))
+
+  IAM_Role(:EnhancedMonitoringRole) {
+    Condition(:EnableEnhancedMonitoring)
+    AssumeRolePolicyDocument service_assume_role_policy('monitoring.rds')
+    ManagedPolicyArns ['arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole']
+  }
+
   if engine_mode == 'serverless'
     RDS_DBInstance(:ServerlessDBInstance) {
       Engine 'aurora-postgresql'
       DBInstanceClass 'db.serverless'
       DBClusterIdentifier Ref(:DBCluster)
+      MonitoringInterval FnIf(:EnableEnhancedMonitoring, Ref(:EnhancedMonitoringInterval), Ref('AWS::NoValue'))
+      MonitoringRoleArn FnIf(:EnableEnhancedMonitoring, FnGetAtt(:EnhancedMonitoringRole, :Arn), Ref('AWS::NoValue'))
     }
 
   else
@@ -241,6 +251,8 @@ CloudFormation do
       PreferredMaintenanceWindow writer_maintenance_window unless writer_maintenance_window.nil?
       PubliclyAccessible 'false'
       DBInstanceClass Ref(:WriterInstanceType)
+      MonitoringInterval FnIf(:EnableEnhancedMonitoring, Ref(:EnhancedMonitoringInterval), Ref('AWS::NoValue'))
+      MonitoringRoleArn FnIf(:EnableEnhancedMonitoring, FnGetAtt(:EnhancedMonitoringRole, :Arn), Ref('AWS::NoValue'))
       Tags aurora_tags
     }
 
@@ -257,6 +269,8 @@ CloudFormation do
       PreferredMaintenanceWindow reader_maintenance_window unless reader_maintenance_window.nil?
       PubliclyAccessible 'false'
       DBInstanceClass Ref(:ReaderInstanceType)
+      MonitoringInterval FnIf(:EnableEnhancedMonitoring, Ref(:EnhancedMonitoringInterval), Ref('AWS::NoValue'))
+      MonitoringRoleArn FnIf(:EnableEnhancedMonitoring, FnGetAtt(:EnhancedMonitoringRole, :Arn), Ref('AWS::NoValue'))
       Tags aurora_tags
     }
 

--- a/spec/enhanced_monitoring_spec.rb
+++ b/spec/enhanced_monitoring_spec.rb
@@ -1,0 +1,98 @@
+require 'yaml'
+
+describe 'compiled component aurora-postgres' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/enhanced_monitoring.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/enhanced_monitoring/aurora-postgres.compiled.yaml") }
+
+  context "Condition" do
+    context "EnableEnhancedMonitoring" do
+      let(:condition) { template["Conditions"]["EnableEnhancedMonitoring"] }
+
+      it "is based on EnhancedMonitoringInterval parameter not being 0" do
+        expect(condition).to eq({"Fn::Not"=>[{"Fn::Equals"=>[{"Ref"=>"EnhancedMonitoringInterval"}, "0"]}]})
+      end
+    end
+  end
+
+  context "Parameter" do
+    context "EnhancedMonitoringInterval" do
+      let(:parameter) { template["Parameters"]["EnhancedMonitoringInterval"] }
+
+      it "exists" do
+        expect(parameter).not_to be_nil
+      end
+
+      it "has default value of 0" do
+        expect(parameter["Default"]).to eq("0")
+      end
+
+      it "has allowed values" do
+        expect(parameter["AllowedValues"]).to eq(["0", "1", "5", "10", "15", "30", "60"])
+      end
+    end
+  end
+
+  context "Resource" do
+
+    context "EnhancedMonitoringRole" do
+      let(:resource) { template["Resources"]["EnhancedMonitoringRole"] }
+
+      it "is of type AWS::IAM::Role" do
+        expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+
+      it "has condition EnableEnhancedMonitoring" do
+        expect(resource["Condition"]).to eq("EnableEnhancedMonitoring")
+      end
+
+      it "has monitoring.rds.amazonaws.com as the service principal" do
+        statement = resource["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]
+        expect(statement["Principal"]["Service"]).to eq("monitoring.rds.amazonaws.com")
+      end
+
+      it "has the AmazonRDSEnhancedMonitoringRole managed policy" do
+        expect(resource["Properties"]["ManagedPolicyArns"]).to include("arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole")
+      end
+    end
+
+    context "DBClusterInstanceWriter" do
+      let(:resource) { template["Resources"]["DBClusterInstanceWriter"] }
+
+      it "has MonitoringInterval with Fn::If" do
+        expect(resource["Properties"]["MonitoringInterval"]).to eq({
+          "Fn::If" => ["EnableEnhancedMonitoring", {"Ref" => "EnhancedMonitoringInterval"}, {"Ref" => "AWS::NoValue"}]
+        })
+      end
+
+      it "has MonitoringRoleArn with Fn::If" do
+        expect(resource["Properties"]["MonitoringRoleArn"]).to eq({
+          "Fn::If" => ["EnableEnhancedMonitoring", {"Fn::GetAtt" => ["EnhancedMonitoringRole", "Arn"]}, {"Ref" => "AWS::NoValue"}]
+        })
+      end
+    end
+
+    context "DBClusterInstanceReader" do
+      let(:resource) { template["Resources"]["DBClusterInstanceReader"] }
+
+      it "has MonitoringInterval with Fn::If" do
+        expect(resource["Properties"]["MonitoringInterval"]).to eq({
+          "Fn::If" => ["EnableEnhancedMonitoring", {"Ref" => "EnhancedMonitoringInterval"}, {"Ref" => "AWS::NoValue"}]
+        })
+      end
+
+      it "has MonitoringRoleArn with Fn::If" do
+        expect(resource["Properties"]["MonitoringRoleArn"]).to eq({
+          "Fn::If" => ["EnableEnhancedMonitoring", {"Fn::GetAtt" => ["EnhancedMonitoringRole", "Arn"]}, {"Ref" => "AWS::NoValue"}]
+        })
+      end
+    end
+
+  end
+
+end

--- a/tests/enhanced_monitoring.test.yaml
+++ b/tests/enhanced_monitoring.test.yaml
@@ -1,0 +1,7 @@
+test_metadata:
+  type: config
+  name: enhanced_monitoring
+  description: enable enhanced monitoring on db instances
+
+family: aurora-postgresql14
+engine_version: 14.6


### PR DESCRIPTION
## Summary

Adds support for RDS Enhanced Monitoring on Aurora PostgreSQL instances via a runtime CloudFormation parameter — no recompile needed to enable/disable.

## Usage

Set the `EnhancedMonitoringInterval` parameter at deploy time:

```
# Enable with 60 second granularity
EnhancedMonitoringInterval=60

# Disable (default)
EnhancedMonitoringInterval=0
```

Valid intervals: `0` (disabled), `1`, `5`, `10`, `15`, `30`, `60` seconds.

## Implementation

- **Parameter:** `EnhancedMonitoringInterval` (default: `0`, allowed values enforced)
- **Condition:** `EnableEnhancedMonitoring` — true when interval != 0
- **IAM Role:** `EnhancedMonitoringRole` — only created when condition is true (uses `AmazonRDSEnhancedMonitoringRole` managed policy)
- **DB Instances:** `MonitoringInterval` and `MonitoringRoleArn` use `Fn::If` with `AWS::NoValue` to cleanly omit properties when disabled

Applies to all instance types: writer, reader, and serverless.

## Tests

- `tests/enhanced_monitoring.test.yaml` — test config
- `spec/enhanced_monitoring_spec.rb` — rspec tests covering condition, parameter, IAM role, and instance properties (12 assertions)

## Motivation

Enhanced Monitoring provides OS-level metrics (CPU, memory, file system, disk I/O) at per-second granularity, essential for diagnosing performance issues not visible in standard CloudWatch metrics.